### PR TITLE
Resolve issue where RebornStorage advanced transmitter can't be used in 1.20.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,10 +118,13 @@ repositories {
 dependencies {
     minecraft 'net.minecraftforge:forge:1.20.1-47.0.3'
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
-    compileOnly "com.refinedmods:refinedstorage:1.12.3"
-    runtimeOnly fg.deobf("com.refinedmods:refinedstorage:1.12.3") {
+    compileOnly "com.refinedmods:refinedstorage:1.12.4"
+    runtimeOnly fg.deobf("com.refinedmods:refinedstorage:1.12.4") {
         transitive false
     }
+    compileOnly fg.deobf("curse.maven:rebornstorage-256662:4861934")
+    runtimeOnly fg.deobf("curse.maven:rebornstorage-256662:4861934")
+
     runtimeOnly fg.deobf("mezz.jei:jei-1.20.1-forge:15.0.0.12")
 }
 

--- a/src/main/java/uk/co/hexeption/rsinfinitybooster/mixins/MixinAdvancedWirelessTransmitterNode.java
+++ b/src/main/java/uk/co/hexeption/rsinfinitybooster/mixins/MixinAdvancedWirelessTransmitterNode.java
@@ -1,0 +1,56 @@
+package uk.co.hexeption.rsinfinitybooster.mixins;
+
+
+import com.refinedmods.refinedstorage.RS;
+import com.refinedmods.refinedstorage.apiimpl.network.node.WirelessTransmitterNetworkNode;
+import com.refinedmods.refinedstorage.inventory.item.UpgradeItemHandler;
+import net.gigabit101.rebornstorage.nodes.AdvancedWirelessTransmitterNode;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import uk.co.hexeption.rsinfinitybooster.RSInfinityBooster;
+import uk.co.hexeption.rsinfinitybooster.utils.CardUtil;
+
+@Mixin(value = AdvancedWirelessTransmitterNode.class, remap = false)
+public class MixinAdvancedWirelessTransmitterNode {
+
+    @Shadow
+    @Final
+    private UpgradeItemHandler upgrades;
+
+
+    @Inject(method = "getRange", at = @At("HEAD"), cancellable = true)
+    private void getRange(CallbackInfoReturnable<Integer> cir) {
+
+        if (CardUtil.isInfinityCard(upgrades)) {
+            cir.setReturnValue(Integer.MAX_VALUE);
+        }
+
+        if (CardUtil.isDimensionCard(upgrades)) {
+            cir.setReturnValue(Integer.MAX_VALUE);
+        }
+    }
+
+    @Inject(method = "getEnergyUsage", at = @At("HEAD"), cancellable = true)
+    private void getEnergyUsage(CallbackInfoReturnable<Integer> cir) {
+
+        if (CardUtil.isBothCards(upgrades)) {
+            cir.setReturnValue(RS.SERVER_CONFIG.getWirelessTransmitter().getUsage() + RSInfinityBooster.SERVER_CONFIG.getInfinityCard().getEnergyUsage() + RSInfinityBooster.SERVER_CONFIG.getDimensionCard().getEnergyUsage());
+            return;
+        }
+
+        if (CardUtil.isInfinityCard(upgrades)) {
+            cir.setReturnValue(RS.SERVER_CONFIG.getWirelessTransmitter().getUsage() + RSInfinityBooster.SERVER_CONFIG.getInfinityCard().getEnergyUsage());
+            return;
+        }
+
+        if (CardUtil.isDimensionCard(upgrades)) {
+            cir.setReturnValue(RS.SERVER_CONFIG.getWirelessTransmitter().getUsage() + RSInfinityBooster.SERVER_CONFIG.getDimensionCard().getEnergyUsage());
+            return;
+        }
+
+    }
+}

--- a/src/main/java/uk/co/hexeption/rsinfinitybooster/mixins/MixinNetworkItemManager.java
+++ b/src/main/java/uk/co/hexeption/rsinfinitybooster/mixins/MixinNetworkItemManager.java
@@ -7,12 +7,15 @@ import com.refinedmods.refinedstorage.api.network.item.INetworkItemProvider;
 import com.refinedmods.refinedstorage.api.network.node.INetworkNode;
 import com.refinedmods.refinedstorage.apiimpl.network.item.NetworkItemManager;
 import com.refinedmods.refinedstorage.apiimpl.network.node.WirelessTransmitterNetworkNode;
+import com.refinedmods.refinedstorage.inventory.item.BaseItemHandler;
 import com.refinedmods.refinedstorage.inventory.player.PlayerSlot;
+import net.gigabit101.rebornstorage.nodes.AdvancedWirelessTransmitterNode;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -29,32 +32,43 @@ import java.util.Map;
 @Mixin(value = NetworkItemManager.class, remap = false)
 public abstract class MixinNetworkItemManager implements INetworkItemManager {
 
-	@Shadow
-	@Final
-	private INetwork network;
+    @Shadow
+    @Final
+    private INetwork network;
 
-	@Shadow
-	@Final
-	private Map<Player, INetworkItem> items;
+    @Shadow
+    @Final
+    private Map<Player, INetworkItem> items;
 
-	@Inject(method = "open", at = @At("HEAD"), cancellable = true)
-	private void onOpen(Player player, ItemStack itemStack, PlayerSlot playerSlot, CallbackInfo ci) {
-		network.getNodeGraph().all().forEach(iNetworkNode -> {
-			INetworkNode node = iNetworkNode.getNode();
-			if (node instanceof WirelessTransmitterNetworkNode transmitter) {
-				if (!transmitter.isActive()) {
-					return;
-				}
-				if (CardUtil.isDimensionCard(transmitter.getUpgrades())) {
-					INetworkItem item = ((INetworkItemProvider) itemStack.getItem()).provide(this, player, itemStack, playerSlot);
-					if (item.onOpen(this.network)) {
-						this.items.put(player, item);
-					}
-					ci.cancel();
-				}
-			}
-		});
-	}
+
+    @Unique
+    private void rSInfinityBooster$handleTransmitterOpen(Player player, ItemStack itemStack, PlayerSlot playerSlot, INetworkNode node, BaseItemHandler upgrades, CallbackInfo ci) {
+        if (!node.isActive()) {
+            return;
+        }
+        if (CardUtil.isDimensionCard(upgrades)) {
+            INetworkItem item = ((INetworkItemProvider) itemStack.getItem()).provide(this, player, itemStack, playerSlot);
+            if (item.onOpen(this.network)) {
+                this.items.put(player, item);
+            }
+            ci.cancel();
+        }
+    }
+
+
+    @Inject(method = "open", at = @At("HEAD"), cancellable = true)
+    private void onOpen(Player player, ItemStack itemStack, PlayerSlot playerSlot, CallbackInfo ci) {
+        network.getNodeGraph().all().forEach(iNetworkNode -> {
+            INetworkNode node = iNetworkNode.getNode();
+            if (node instanceof WirelessTransmitterNetworkNode transmitter) {
+                rSInfinityBooster$handleTransmitterOpen(player, itemStack, playerSlot, node, transmitter.getUpgrades(), ci);
+            }
+            else if (node instanceof AdvancedWirelessTransmitterNode transmitter) {
+                rSInfinityBooster$handleTransmitterOpen(player, itemStack, playerSlot, node, transmitter.getUpgrades(), ci);
+            }
+
+        });
+    }
 
 
 }

--- a/src/main/resources/rsinfinitybooster.mixins.json
+++ b/src/main/resources/rsinfinitybooster.mixins.json
@@ -6,6 +6,7 @@
   "mixins": [
     "MixinNetworkItemManager",
     "MixinsWirelessTransmitterNetworkNode",
+    "MixinAdvancedWirelessTransmitterNode",
     "MixinUpgradeItemValidator"
   ],
   "minVersion": "0.8"


### PR DESCRIPTION
Resolve issue where RebornStorage advanced transmitter can't be used in 1.20.1